### PR TITLE
Add `appImageOptions` to JPackage tasks

### DIFF
--- a/src/main/java/org/gradlex/javamodule/packaging/JavaModulePackagingExtension.java
+++ b/src/main/java/org/gradlex/javamodule/packaging/JavaModulePackagingExtension.java
@@ -21,7 +21,6 @@ import org.gradle.api.NamedDomainObjectContainer;
 import org.gradle.api.NamedDomainObjectSet;
 import org.gradle.api.NonNullApi;
 import org.gradle.api.Project;
-import org.gradle.api.Task;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.ConfigurationContainer;
 import org.gradle.api.attributes.Attribute;

--- a/src/main/java/org/gradlex/javamodule/packaging/JavaModulePackagingExtension.java
+++ b/src/main/java/org/gradlex/javamodule/packaging/JavaModulePackagingExtension.java
@@ -256,6 +256,7 @@ abstract public class JavaModulePackagingExtension {
             t.getJlinkOptions().convention(getJlinkOptions());
             t.getAddModules().convention(getAddModules());
             t.getOptions().convention(target.getOptions());
+            t.getAppImageOptions().convention(target.getAppImageOptions());
             t.getPackageTypes().convention(target.getPackageTypes());
             t.getSingleStepPackaging().convention(target.getSingleStepPackaging());
             t.getResources().from(getResources());

--- a/src/main/java/org/gradlex/javamodule/packaging/model/Target.java
+++ b/src/main/java/org/gradlex/javamodule/packaging/model/Target.java
@@ -31,6 +31,7 @@ abstract public class Target {
 
     abstract public ListProperty<String> getPackageTypes();
     abstract public ListProperty<String> getOptions();
+    abstract public ListProperty<String> getAppImageOptions();
 
     abstract public ConfigurableFileCollection getTargetResources();
 

--- a/src/main/java/org/gradlex/javamodule/packaging/tasks/Jpackage.java
+++ b/src/main/java/org/gradlex/javamodule/packaging/tasks/Jpackage.java
@@ -204,9 +204,9 @@ abstract public class Jpackage extends DefaultTask {
                         }
                     } else {
                         e.args("--app-image", appImageFolder().getPath());
-                    }
-                    for (String option : getOptions().get()) {
-                        e.args(option);
+                        for (String option : getOptions().get()) {
+                            e.args(option);
+                        }
                     }
                 })
         );
@@ -271,6 +271,9 @@ abstract public class Jpackage extends DefaultTask {
         }
         if (!getAddModules().get().isEmpty()) {
             e.args("--add-modules", String.join(",", getAddModules().get()));
+        }
+        for (String option : getOptions().get()) {
+            e.args(option);
         }
         if (getVerbose().get()) {
             e.args("--verbose");

--- a/src/main/java/org/gradlex/javamodule/packaging/tasks/Jpackage.java
+++ b/src/main/java/org/gradlex/javamodule/packaging/tasks/Jpackage.java
@@ -114,6 +114,9 @@ abstract public class Jpackage extends DefaultTask {
     abstract public ListProperty<String> getOptions();
 
     @Input
+    abstract public ListProperty<String> getAppImageOptions();
+
+    @Input
     abstract public ListProperty<String> getPackageTypes();
 
     @Input
@@ -238,6 +241,9 @@ abstract public class Jpackage extends DefaultTask {
                     getDestination().get().getAsFile().getPath()
             );
             configureJPackageArguments(e, resourcesDir);
+            for (String option : getAppImageOptions().get()) {
+                e.args(option);
+            }
         });
     }
 

--- a/src/main/java/org/gradlex/javamodule/packaging/tasks/Jpackage.java
+++ b/src/main/java/org/gradlex/javamodule/packaging/tasks/Jpackage.java
@@ -204,9 +204,9 @@ abstract public class Jpackage extends DefaultTask {
                         }
                     } else {
                         e.args("--app-image", appImageFolder().getPath());
-                        for (String option : getOptions().get()) {
-                            e.args(option);
-                        }
+                    }
+                    for (String option : getOptions().get()) {
+                        e.args(option);
                     }
                 })
         );
@@ -271,9 +271,6 @@ abstract public class Jpackage extends DefaultTask {
         }
         if (!getAddModules().get().isEmpty()) {
             e.args("--add-modules", String.join(",", getAddModules().get()));
-        }
-        for (String option : getOptions().get()) {
-            e.args(option);
         }
         if (getVerbose().get()) {
             e.args("--verbose");


### PR DESCRIPTION
`--win-console` was not functioning in the  `preview` branch

```kotlin
options.addAll("--win-console")
```

This PR fixes it.

I think, options should be passed in all `app-image` cases, therefore, I left then in there - but also copied them into `configureJPackageArguments`