### PR TITLE
Write out argsFile

### DIFF
--- a/src/main/java/org/gradlex/javamodule/packaging/tasks/Jpackage.java
+++ b/src/main/java/org/gradlex/javamodule/packaging/tasks/Jpackage.java
@@ -278,7 +278,7 @@ public abstract class Jpackage extends DefaultTask {
         try {
             Files.write(argsFile, lines);
         } catch (IOException e) {
-            return "--module-path " + modulePathAsPath;
+            throw new RuntimeException(e);
         }
         return "@" + argsFile.toString();
     }


### PR DESCRIPTION
Fixes #69 

Please guide how to test

    gradle publishToMavenLocal

results in

```
* What went wrong:
Could not read PGP secret key
> unable to decode base64 data: invalid characters encountered at end of base64 data

* Try:
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Get more help at https://help.gradle.org.

BUILD FAILED in 1s
Configuration cache entry discarded due to serialization error.
20:53:46: Execution finished 'publishToMavenLocal'.
```